### PR TITLE
Revert "during nodeBuild: have jenkins resolve dependencies"

### DIFF
--- a/vars/sfNodeNpmBuild.groovy
+++ b/vars/sfNodeNpmBuild.groovy
@@ -6,9 +6,6 @@ def call(body) {
         stage('Dependencies') {
             sh 'cp /home/jenkins/npm-config/.npmrc .'
             sh 'npm config list'
-            sh 'npm cache clean --force'
-            sh 'rm -rf ./node_modules'
-            sh 'rm -rf ./package-lock.json'
             sh 'npm --loglevel info install'
         }
     } catch (e) {


### PR DESCRIPTION
NEVER (!!!111!!!) delete `package-lock.json` on build script!!!!!
The former change was bollocks because:
1. the node is fresh and new and had now `node_modules` anyway
2. the delete of `package-lock.json` removes locked package versions and opens to none reproducing builds and possible breaking package updates 

This reverts commit 3559ea5844a3e74e783ad861b523558eea959ca5.