### PR TITLE
use pom version instead of fixed version

### DIFF
--- a/vars/sfMavenBuildRelease.groovy
+++ b/vars/sfMavenBuildRelease.groovy
@@ -9,7 +9,11 @@ def call(body) {
 
     if ( !config.version ) {
         pom = readMavenPom file: 'pom.xml'
-        config.version = "${pom.version}-BUILD-${env.BUILD_NUMBER}"
+        if ( !pom.version || pom.version == '${global.version}' ) {
+            config.version = "1.0.${env.BUILD_NUMBER}"
+        } else {
+            config.version = "${pom.version}-BUILD-${env.BUILD_NUMBER}"
+        }
     }
 
     container(name: 'maven') {

--- a/vars/sfMavenBuildRelease.groovy
+++ b/vars/sfMavenBuildRelease.groovy
@@ -8,7 +8,8 @@ def call(body) {
     body()
 
     if ( !config.version ) {
-        config.version = "1.0.${env.BUILD_NUMBER}"
+        pom = readMavenPom file: 'pom.xml'
+        config.version = "${pom.version}-BUILD-${env.BUILD_NUMBER}"
     }
 
     container(name: 'maven') {


### PR DESCRIPTION
To support the gitflow we have to use the `version` property form the `pom.xml`.

This will result in the following build versions:
- release/1.1.0 -> `1.1.0-RC-SNAPSHOT-BUILD-82`
- develop -> `1.1.1-SNAPSHOT-BUILD-83`
- master -> `1.1.0-BUILD-84`