### PR TITLE
return the full config file instead just the version

### DIFF
--- a/vars/sfMavenBuildRelease.groovy
+++ b/vars/sfMavenBuildRelease.groovy
@@ -39,5 +39,5 @@ def call(body) {
     //   reportName: "Docs"
     // ])
 
-    return config.version
+    return config
 }


### PR DESCRIPTION
To correctly use the different pipeline function we identified that we need to return the full config file