### PR TITLE
get actual timestamp

### DIFF
--- a/vars/sfMavenBuildRelease.groovy
+++ b/vars/sfMavenBuildRelease.groovy
@@ -15,7 +15,8 @@ def call(body) {
 	    if ( !pom.version || pom.version == '${global.version}' || pom.version.contains('GENERATED') ) {
             config.version = "1.0.${env.BUILD_NUMBER}"
         } else {
-            config.version = "${pom.version}-BUILD-${env.BUILD_NUMBER}"
+	    def buildReleaseTimestamp = sh(returnStdout: true, script: 'date +%Y%m%d%H%M%S').trim()
+            config.version = "${pom.version}-BUILD-${buildReleaseTimestamp}-${env.BUILD_NUMBER}"
         }
     }
 


### PR DESCRIPTION
as discussed: lets put the actual timestamp into our config.version. 

( not sure if this would work on Jenkins on Windows but with all other install environments it will work because they all have a shell. in the beginning I just wanted to calculate the timestamp in Groovy/Java .. but that is not allowed with our Pipeline; error message is "Scripts not permitted to use staticMethod ... " )